### PR TITLE
关闭normal-player时 重置歌词界面为显示cd界面；修改歌词显示为折行显示

### DIFF
--- a/src/application/Player/index.js
+++ b/src/application/Player/index.js
@@ -1,5 +1,5 @@
-import React, {useRef, useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import React, { useRef, useState, useEffect } from "react";
+import { connect } from "react-redux";
 import {
   changePlayingState,
   changeShowPlayList,
@@ -8,23 +8,23 @@ import {
   changePlayList,
   changePlayMode,
   changeFullScreen
-} from './store/actionCreators';
-import { isEmptyObject, shuffle, findIndex, getSongUrl } from '../../api/utils';
-import PlayList from './play-list/index';
-import Toast from './../../baseUI/toast/index';
-import Lyric from '../../api/lyric-parser';
-import MiniPlayer from './mini-player'
-import NormalPlayer from './normal-player';
-import { playMode } from './../../api/config';
-import { getLyricRequest } from './../../api/request';
+} from "./store/actionCreators";
+import { isEmptyObject, shuffle, findIndex, getSongUrl } from "../../api/utils";
+import PlayList from "./play-list/index";
+import Toast from "./../../baseUI/toast/index";
+import Lyric from "../../api/lyric-parser";
+import MiniPlayer from "./mini-player";
+import NormalPlayer from "./normal-player";
+import { playMode } from "./../../api/config";
+import { getLyricRequest } from "./../../api/request";
 
 function Player(props) {
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
-  const [currentPlayingLyric, setPlayingLyric] = useState('');
-  const [modeText, setModeText] = useState('');
+  const [currentPlayingLyric, setPlayingLyric] = useState("");
+  const [modeText, setModeText] = useState("");
 
-  let percent = isNaN(currentTime/duration) ? 0  :currentTime/duration;
+  let percent = isNaN(currentTime / duration) ? 0 : currentTime / duration;
 
   const {
     playing,
@@ -46,7 +46,7 @@ function Player(props) {
     toggleFullScreenDispatch
   } = props;
 
-  const [preSong, setPreSong] = useState({}); 
+  const [preSong, setPreSong] = useState({});
 
   const audioRef = useRef();
   const toastRef = useRef();
@@ -56,11 +56,17 @@ function Player(props) {
   const songReady = useRef(true);
 
   useEffect(() => {
-    if(!playList.length || currentIndex === -1 || !playList[currentIndex] || playList[currentIndex].id === preSong.id) return;
-    if(!songReady.current){
-      alert("操作过快！")
+    if (
+      !playList.length ||
+      currentIndex === -1 ||
+      !playList[currentIndex] ||
+      playList[currentIndex].id === preSong.id
+    )
       return;
-    } 
+    if (!songReady.current) {
+      alert("操作过快！");
+      return;
+    }
     songReady.current = false;
     let current = playList[currentIndex];
     changeCurrentDispatch(current);
@@ -72,7 +78,7 @@ function Player(props) {
     togglePlayingDispatch(true);
     getLyric(current.id);
     setCurrentTime(0);
-    setDuration(current.dt/1000 | 0);
+    setDuration((current.dt / 1000) | 0);
     // eslint-disable-next-line
   }, [currentIndex, playList]);
 
@@ -81,112 +87,114 @@ function Player(props) {
   }, [playing]);
 
   useEffect(() => {
-    if(!fullScreen) return;
-    if(currentLineNum.current && currentLyric.current.lines.length) {
+    if (!fullScreen) return;
+    if (currentLineNum.current && currentLyric.current.lines.length) {
       handleLyric({
-        lineNum: currentLineNum.current, 
+        lineNum: currentLineNum.current,
         txt: currentLyric.current.lines[currentLineNum.current].txt
-      }); 
+      });
     }
   }, [fullScreen]);
 
-  const handleLyric = ({lineNum, txt}) => {
+  const handleLyric = ({ lineNum, txt }) => {
     currentLineNum.current = lineNum;
     setPlayingLyric(txt);
   };
 
-  const getLyric = (id) => {
-    let lyric = '';
-    if(currentLyric.current) {
+  const getLyric = id => {
+    let lyric = "";
+    if (currentLyric.current) {
       currentLyric.current.stop();
     }
-    getLyricRequest(id).then(data => {
-      if(!data.lrc)return;
-      lyric = data.lrc.lyric;
-      audioRef.current.play();
-      currentLyric.current = new Lyric(lyric, handleLyric);
-      currentLyric.current.play();
-      currentLineNum.current = 0;
-      currentLyric.current.seek(0);
-    }).catch(() => {
-      audioRef.current.play();
-    })
+    getLyricRequest(id)
+      .then(data => {
+        if (!data.lrc) return;
+        lyric = data.lrc.lyric;
+        audioRef.current.play();
+        currentLyric.current = new Lyric(lyric, handleLyric);
+        currentLyric.current.play();
+        currentLineNum.current = 0;
+        currentLyric.current.seek(0);
+      })
+      .catch(() => {
+        audioRef.current.play();
+      });
   };
 
   const clickPlaying = (e, state) => {
     e.stopPropagation();
     togglePlayingDispatch(state);
     currentLyric.current.togglePlay();
-  }
+  };
 
-  const onProgressChange = (curPercent) => {
-    const newTime = curPercent*duration;
+  const onProgressChange = curPercent => {
+    const newTime = curPercent * duration;
     setCurrentTime(newTime);
     audioRef.current.currentTime = newTime;
-    if(!playing) {
+    if (!playing) {
       togglePlayingDispatch(true);
     }
-    if(currentLyric.current) {
+    if (currentLyric.current) {
       currentLyric.current.seek(newTime * 1000);
     }
-  }
+  };
 
-  const updateTime = (e) => {
+  const updateTime = e => {
     setCurrentTime(e.target.currentTime);
   };
 
   const handleLoop = () => {
-    audioRef.current.currentTime =  0;
+    audioRef.current.currentTime = 0;
     changePlayingState(true);
     audioRef.current.play();
-    if(currentLyric.current) {
+    if (currentLyric.current) {
       currentLyric.current.seek(0);
     }
-  }
+  };
 
   const handlePrev = () => {
-    if(playList.length === 1) {
+    if (playList.length === 1) {
       handleLoop();
       return;
     }
     let index = currentIndex - 1;
-    if(index === 0) index = playList.length - 1;
-    if(!playing) togglePlayingDispatch(true);
+    if (index === 0) index = playList.length - 1;
+    if (!playing) togglePlayingDispatch(true);
     changeCurrentIndexDispatch(index);
-  }
+  };
 
   const handleNext = () => {
-    if(playList.length === 1) {
+    if (playList.length === 1) {
       handleLoop();
       return;
     }
     let index = currentIndex + 1;
-    if(index === playList.length) index = 0;
-    if(!playing) togglePlayingDispatch(true);
+    if (index === playList.length) index = 0;
+    if (!playing) togglePlayingDispatch(true);
     changeCurrentIndexDispatch(index);
-  }
+  };
 
   const handleEnd = () => {
-    if(mode === playMode.loop){
+    if (mode === playMode.loop) {
       handleLoop();
     } else {
       handleNext();
     }
-  }
+  };
 
   const changeMode = () => {
-    let newMode = (mode + 1)%3;
-    if(newMode === 0){
+    let newMode = (mode + 1) % 3;
+    if (newMode === 0) {
       //顺序模式
       changePlayListDispatch(sequencePlayList);
       let index = findIndex(currentSong, sequencePlayList);
       changeCurrentIndexDispatch(index);
       setModeText("顺序循环");
-    }else if(newMode === 1){
+    } else if (newMode === 1) {
       //单曲循环
       changePlayListDispatch(sequencePlayList);
       setModeText("单曲循环");
-    } else if(newMode === 2) {
+    } else if (newMode === 2) {
       //随机播放
       let newList = shuffle(sequencePlayList);
       let index = findIndex(currentSong, newList);
@@ -196,14 +204,13 @@ function Player(props) {
     }
     changeModeDispatch(newMode);
     toastRef.current.show();
-  }
+  };
   const handleError = () => {
     alert("播放出错");
-  }
+  };
   return (
     <div>
-      {
-        isEmptyObject(currentSong) ? null :
+      {isEmptyObject(currentSong) ? null : (
         <NormalPlayer
           song={currentSong}
           full={fullScreen}
@@ -223,11 +230,9 @@ function Player(props) {
           clickPlaying={clickPlaying}
           toggleFullScreenDispatch={toggleFullScreenDispatch}
           togglePlayListDispatch={togglePlayListDispatch}
-        >
-        </NormalPlayer>
-      }
-      {
-        isEmptyObject(currentSong) ? null :
+        ></NormalPlayer>
+      )}
+      {isEmptyObject(currentSong) ? null : (
         <MiniPlayer
           playing={playing}
           full={fullScreen}
@@ -237,39 +242,40 @@ function Player(props) {
           setFullScreen={toggleFullScreenDispatch}
           togglePlayList={togglePlayListDispatch}
         ></MiniPlayer>
-      }
+      )}
 
       <PlayList></PlayList>
-      <audio 
-        ref={audioRef} 
+      <audio
+        ref={audioRef}
         onTimeUpdate={updateTime}
         onEnded={handleEnd}
         onError={handleError}
       ></audio>
       <Toast text={modeText} ref={toastRef}></Toast>
     </div>
-  )
+  );
 }
 
 // 映射Redux全局的state到组件的props上
-const mapStateToProps = (state) => ({
-  fullScreen: state.getIn(['player', 'fullScreen']),
-  playing: state.getIn(['player', 'playing']),
-  currentSong: state.getIn(['player', 'currentSong']).toJS(),
-  showPlayList: state.getIn(['player', 'showPlayList']),
-  mode: state.getIn(['player', 'mode']),
-  currentIndex: state.getIn(['player', 'currentIndex']),
-  playList: state.getIn(['player', 'playList']).toJS(),
-  sequencePlayList: state.getIn(['player', 'sequencePlayList'])
+const mapStateToProps = state => ({
+  fullScreen: state.getIn(["player", "fullScreen"]),
+  playing: state.getIn(["player", "playing"]),
+  currentSong: state.getIn(["player", "currentSong"]).toJS(),
+  showPlayList: state.getIn(["player", "showPlayList"]),
+  mode: state.getIn(["player", "mode"]),
+  currentIndex: state.getIn(["player", "currentIndex"]),
+  playList: state.getIn(["player", "playList"]).toJS(),
+  sequencePlayList: state.getIn(["player", "sequencePlayList"])
 });
 
 // 映射dispatch到props上
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     togglePlayingDispatch(data) {
       dispatch(changePlayingState(data));
     },
     toggleFullScreenDispatch(data) {
+      console.log("data", data);
       dispatch(changeFullScreen(data));
     },
     togglePlayListDispatch(data) {
@@ -287,8 +293,11 @@ const mapDispatchToProps = (dispatch) => {
     changePlayListDispatch(data) {
       dispatch(changePlayList(data));
     }
-  }
+  };
 };
 
 // 将ui组件包装成容器组件
-export default connect(mapStateToProps, mapDispatchToProps)(React.memo(Player));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(React.memo(Player));

--- a/src/application/Player/normal-player/index.js
+++ b/src/application/Player/normal-player/index.js
@@ -1,10 +1,10 @@
-import React, { useRef, useEffect } from 'react';
-import { CSSTransition } from 'react-transition-group';
-import animations from 'create-keyframe-animation';
-import ProgressBar from '../../../baseUI/progress-bar/index';
-import Scroll from '../../../baseUI/scroll/index';
-import { playMode } from '../../../api/config';
-import { prefixStyle, formatPlayTime, getName } from '../../../api/utils';
+import React, { useRef, useEffect } from "react";
+import { CSSTransition } from "react-transition-group";
+import animations from "create-keyframe-animation";
+import ProgressBar from "../../../baseUI/progress-bar/index";
+import Scroll from "../../../baseUI/scroll/index";
+import { playMode } from "../../../api/config";
+import { prefixStyle, formatPlayTime, getName } from "../../../api/utils";
 import {
   NormalPlayerContainer,
   Top,
@@ -14,35 +14,35 @@ import {
   Operators,
   CDWrapper,
   LyricContainer,
-  LyricWrapper,
-} from './style';
+  LyricWrapper
+} from "./style";
 
 function NormalPlayer(props) {
-  const { 
-    full, 
-    song, 
-    mode, 
-    playing, 
-    percent, 
-    currentTime, 
-    duration, 
-    currentLineNum, 
-    currentPlayingLyric, 
-    currentLyric 
+  const {
+    full,
+    song,
+    mode,
+    playing,
+    percent,
+    currentTime,
+    duration,
+    currentLineNum,
+    currentPlayingLyric,
+    currentLyric
   } = props;
 
-  const { 
-    changeMode, 
-    handlePrev, 
-    handleNext, 
-    onProgressChange, 
-    clickPlaying, 
-    toggleFullScreenDispatch, 
-    togglePlayListDispatch 
+  const {
+    changeMode,
+    handlePrev,
+    handleNext,
+    onProgressChange,
+    clickPlaying,
+    toggleFullScreenDispatch,
+    togglePlayListDispatch
   } = props;
 
   //处理transform的浏览器兼容问题
-  const transform = prefixStyle('transform');
+  const transform = prefixStyle("transform");
 
   const normalPlayerRef = useRef();
   const lyricScrollRef = useRef();
@@ -93,7 +93,7 @@ function NormalPlayer(props) {
   };
 
   const enter = () => {
-    normalPlayerRef.current.style.display = 'block';
+    normalPlayerRef.current.style.display = "block";
     const { x, y, scale } = _getPosAndScale();
     let animation = {
       0: {
@@ -107,43 +107,46 @@ function NormalPlayer(props) {
       }
     };
     animations.registerAnimation({
-      name: 'move',
+      name: "move",
       animation,
       presets: {
         duration: 400,
-        easing: 'linear'
+        easing: "linear"
       }
     });
-    animations.runAnimation(cdWrapperRef.current, 'move');
+    animations.runAnimation(cdWrapperRef.current, "move");
   };
 
   const afterEnter = () => {
     const cdWrapperDom = cdWrapperRef.current;
-    animations.unregisterAnimation('move');
-    cdWrapperDom.style.animation = '';
+    animations.unregisterAnimation("move");
+    cdWrapperDom.style.animation = "";
   };
 
   const leave = () => {
     if (!cdWrapperRef.current) return;
     const cdWrapperDom = cdWrapperRef.current;
-    cdWrapperDom.style.transition = 'all 0.4s';
+    cdWrapperDom.style.transition = "all 0.4s";
     const { x, y, scale } = _getPosAndScale();
-    cdWrapperDom.style[transform] = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+    cdWrapperDom.style[
+      transform
+    ] = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
   };
 
   const afterLeave = () => {
     if (!cdWrapperRef.current) return;
     const cdWrapperDom = cdWrapperRef.current;
-    cdWrapperDom.style.transition = ''
-    cdWrapperDom.style[transform] = '';
-    normalPlayerRef.current.style.display = 'none';
+    cdWrapperDom.style.transition = "";
+    cdWrapperDom.style[transform] = "";
+    normalPlayerRef.current.style.display = "none";
+    currentState.current = "";
   };
 
   const toggleCurrentState = () => {
-    if (currentState.current !== 'lyric') {
-      currentState.current = 'lyric';
+    if (currentState.current !== "lyric") {
+      currentState.current = "lyric";
     } else {
-      currentState.current = '';
+      currentState.current = "";
     }
   };
 
@@ -160,7 +163,12 @@ function NormalPlayer(props) {
     >
       <NormalPlayerContainer ref={normalPlayerRef}>
         <div className="background">
-          <img src={song.al.picUrl + "?param=300x300"} width="100%" height="100%" alt="歌曲图片" />
+          <img
+            src={song.al.picUrl + "?param=300x300"}
+            width="100%"
+            height="100%"
+            alt="歌曲图片"
+          />
         </div>
         <div className="background layer"></div>
         <Top className="top">
@@ -174,13 +182,21 @@ function NormalPlayer(props) {
           <CSSTransition
             timeout={400}
             classNames="fade"
-            in={currentState.current !== 'lyric'}
+            in={currentState.current !== "lyric"}
           >
             <CDWrapper
-              style={{ visibility: currentState.current !== 'lyric' ? 'visible' : 'hidden' }}
+              style={{
+                visibility:
+                  currentState.current !== "lyric" ? "visible" : "hidden"
+              }}
             >
               <div className="cd">
-                <img ref={cdImageRef} className={`image play ${playing ? "" : "pause"}`} src={song.al.picUrl + "?param=400x400"} alt="" />
+                <img
+                  ref={cdImageRef}
+                  className={`image play ${playing ? "" : "pause"}`}
+                  src={song.al.picUrl + "?param=400x400"}
+                  alt=""
+                />
               </div>
               <p className="playing_lyric">{currentPlayingLyric}</p>
             </CDWrapper>
@@ -188,28 +204,32 @@ function NormalPlayer(props) {
           <CSSTransition
             timeout={400}
             classNames="fade"
-            in={currentState.current === 'lyric'}
+            in={currentState.current === "lyric"}
           >
             <LyricContainer>
-              <Scroll ref={lyricScrollRef} >
+              <Scroll ref={lyricScrollRef}>
                 <LyricWrapper
-                  style={{ visibility: currentState.current === 'lyric' ? 'visible' : 'hidden' }}
+                  style={{
+                    visibility:
+                      currentState.current === "lyric" ? "visible" : "hidden"
+                  }}
                   className="lyric_wrapper"
                 >
-                  {
-                    currentLyric ?
-                      currentLyric.lines.map((item, index) => {
+                  {currentLyric
+                    ? currentLyric.lines.map((item, index) => {
                         return (
                           <p
-                            className={`text ${currentLineNum === index ? 'current' : ''}`}
+                            className={`text ${
+                              currentLineNum === index ? "current" : ""
+                            }`}
                             key={item + index}
-                            ref={el => lyricLineRefs.current.push(el)}>
+                            ref={el => lyricLineRefs.current.push(el)}
+                          >
                             {item.txt}
                           </p>
-                        )
+                        );
                       })
-                      : null
-                  }
+                    : null}
                 </LyricWrapper>
               </Scroll>
             </LyricContainer>
@@ -219,34 +239,46 @@ function NormalPlayer(props) {
           <ProgressWrapper>
             <span className="time time-l">{formatPlayTime(currentTime)}</span>
             <div className="progress-bar-wrapper">
-              <ProgressBar percent={percent} percentChange={onProgressChange}></ProgressBar>
+              <ProgressBar
+                percent={percent}
+                percentChange={onProgressChange}
+              ></ProgressBar>
             </div>
             <div className="time time-r">{formatPlayTime(duration)}</div>
           </ProgressWrapper>
           <Operators>
             <div className="icon i-left" onClick={changeMode}>
-              <i className="iconfont" dangerouslySetInnerHTML={{ __html: getPlayMode() }}></i>
+              <i
+                className="iconfont"
+                dangerouslySetInnerHTML={{ __html: getPlayMode() }}
+              ></i>
             </div>
             <div className="icon i-left" onClick={handlePrev}>
               <i className="iconfont">&#xe6e1;</i>
             </div>
             <div className="icon i-center">
-              <i className="iconfont"
-                onClick={(e) => clickPlaying(e, !playing)}
-                dangerouslySetInnerHTML={{ __html: playing ? "&#xe723;" : "&#xe731;" }}>
-              </i>
+              <i
+                className="iconfont"
+                onClick={e => clickPlaying(e, !playing)}
+                dangerouslySetInnerHTML={{
+                  __html: playing ? "&#xe723;" : "&#xe731;"
+                }}
+              ></i>
             </div>
             <div className="icon i-right" onClick={handleNext}>
               <i className="iconfont">&#xe718;</i>
             </div>
-            <div className="icon i-right" onClick={() => togglePlayListDispatch(true)}>
+            <div
+              className="icon i-right"
+              onClick={() => togglePlayListDispatch(true)}
+            >
               <i className="iconfont">&#xe640;</i>
             </div>
           </Operators>
         </Bottom>
       </NormalPlayerContainer>
     </CSSTransition>
-  )
+  );
 }
 
 export default React.memo(NormalPlayer);

--- a/src/application/Player/normal-player/style.js
+++ b/src/application/Player/normal-player/style.js
@@ -1,5 +1,5 @@
-import styled, {keyframes} from 'styled-components';
-import style from '../../../assets/global-style';
+import styled, { keyframes } from "styled-components";
+import style from "../../../assets/global-style";
 
 const rotate = keyframes`
   0%{
@@ -8,7 +8,7 @@ const rotate = keyframes`
   100%{
     transform: rotate(360deg);
   }
-`
+`;
 export const NormalPlayerContainer = styled.div`
   position: fixed;
   left: 0;
@@ -26,32 +26,35 @@ export const NormalPlayerContainer = styled.div`
     z-index: -1;
     opacity: 0.6;
     filter: blur(20px);
-    &.layer{
+    &.layer {
       background: ${style["font-color-desc"]};
       opacity: 0.3;
       filter: none;
     }
   }
-  &.normal-enter, &.normal-exit-done{
-    .top{
+  &.normal-enter,
+  &.normal-exit-done {
+    .top {
       transform: translate3d(0, -100px, 0);
     }
-    .bottom{
+    .bottom {
       transform: translate3d(0, 100px, 0);
     }
   }
-  &.normal-enter-active, &.normal-exit-active{
-    .top, .bottom{
+  &.normal-enter-active,
+  &.normal-exit-active {
+    .top,
+    .bottom {
       transform: translate3d(0, 0, 0);
       transition: all 0.4s cubic-bezier(0.86, 0.18, 0.82, 1.32);
     }
     opacity: 1;
     transition: all 0.4s;
   }
-  &.normal-exit-active{
+  &.normal-exit-active {
     opacity: 0;
   }
-`
+`;
 export const Top = styled.div`
   position: relative;
   margin-bottom: 25px;
@@ -81,11 +84,11 @@ export const Top = styled.div`
   .subtitle {
     line-height: 20px;
     text-align: center;
-    font-size: ${style["font-size-m"]};;
+    font-size: ${style["font-size-m"]};
     color: ${style["font-color-desc-v2"]};
     ${style.noWrap()};
   }
-`
+`;
 export const Middle = styled.div`
   position: fixed;
   width: 100%;
@@ -94,27 +97,29 @@ export const Middle = styled.div`
   white-space: nowrap;
   font-size: 0;
   overflow: hidden;
-  .fade-enter{
+  .fade-enter {
     opacity: 0;
   }
-  .fade-enter-active{
+  .fade-enter-active {
     opacity: 1;
     transition: all 0.4s;
   }
-  .fade-enter-done{
+  .fade-enter-done {
     transition: none;
   }
-  .fade-exit-active{
+  .fade-exit-active {
     opacity: 0;
   }
-  .fade-exit-done{
+  .fade-exit-done {
     opacity: 0;
   }
-`
+`;
 export const CDWrapper = styled.div`
   position: absolute;
   margin: auto;
-  top: 10%; left: 0; right: 0; 
+  top: 10%;
+  left: 0;
+  right: 0;
   width: 80%;
   box-sizing: border-box;
   height: 80vw;
@@ -122,7 +127,7 @@ export const CDWrapper = styled.div`
     width: 100%;
     height: 100%;
     border-radius: 50%;
-    .image{
+    .image {
       position: absolute;
       left: 0;
       top: 0;
@@ -132,102 +137,106 @@ export const CDWrapper = styled.div`
       border-radius: 50%;
       border: 10px solid rgba(255, 255, 255, 0.1);
     }
-    .play{
+    .play {
       animation: ${rotate} 20s linear infinite;
-      &.pause{
+      &.pause {
         animation-play-state: paused;
       }
     }
   }
-  .playing_lyric{
+  .playing_lyric {
     margin-top: 20px;
     font-size: 14px;
     line-height: 20px;
+    white-space: normal;
     text-align: center;
-    color: rgba(255, 255,255, 0.5);
+    color: rgba(255, 255, 255, 0.5);
   }
-`
+`;
 export const LyricContainer = styled.div`
   position: absolute;
-  left: 0; right: 0; top: 0; bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
   /* 遮罩 会有模糊效果，看个人喜欢*/
   /* mask-image: -webkit-gradient(linear,left top,left bottom,color-stop(0,hsla(0,0%,100%,0)),color-stop(10%,hsla(0,0%,100%,.6)),color-stop(25%,#fff),color-stop(75%,#fff),color-stop(85%,hsla(0,0%,100%,.6)),to(hsla(0,0%,100%,0)));
   mask-image: linear-gradient(linear,left top,left bottom,color-stop(0,hsla(0,0%,100%,0)),color-stop(10%,hsla(0,0%,100%,.6)),color-stop(25%,#fff),color-stop(75%,#fff),color-stop(85%,hsla(0,0%,100%,.6)),to(hsla(0,0%,100%,0))); */
-`
+`;
 export const LyricWrapper = styled.div`
   position: absolute;
-  left: 0; right: 0;
+  left: 0;
+  right: 0;
   width: 100%;
   box-sizing: border-box;
   text-align: center;
-  p{
+  p {
     line-height: 32px;
-    ${style.noWrap()}
     color: rgba(255, 255, 255, 0.5);
-    font-size: 14px;
-    &.current{
+    white-space: normal;
+    font-size: 18px;
+    &.current {
       color: #fff;
     }
   }
-`
+`;
 export const Bottom = styled.div`
   position: absolute;
   bottom: 50px;
   width: 100%;
-`
+`;
 export const ProgressWrapper = styled.div`
   display: flex;
   align-items: center;
   width: 80%;
   margin: 0px auto;
   padding: 10px 0;
-  .time{
+  .time {
     color: ${style["font-color-desc"]};
     font-size: ${style["font-size-s"]};
     flex: 0 0 30px;
     line-height: 30px;
     width: 30px;
-    &.time-l{
+    &.time-l {
       text-align: left;
     }
-    &.time-r{
+    &.time-r {
       text-align: right;
     }
   }
-  .progress-bar-wrapper{
+  .progress-bar-wrapper {
     flex: 1;
   }
-`
+`;
 export const Operators = styled.div`
   display: flex;
   align-items: center;
-  .icon{
+  .icon {
     font-weight: 300;
     flex: 1;
     color: ${style["font-color-desc"]};
-    &.disable{
+    &.disable {
       color: ${style["theme-color-shadow"]};
     }
-    i{
+    i {
       font-weight: 300;
       font-size: 30px;
     }
   }
-  .i-left{
+  .i-left {
     text-align: right;
   }
-  .i-center{
+  .i-center {
     padding: 0 20px;
     text-align: center;
-    i{
+    i {
       font-size: 40px;
     }
   }
-  .i-right{
+  .i-right {
     text-align: left;
   }
-  .icon-favorite{
+  .icon-favorite {
     color: ${style["theme-color"]};
   }
-`
-
+`;


### PR DESCRIPTION
1。现在播放界面为显示歌词时候，关闭的时候currentState仍然 为lyric，
在afterclose 的方法加入了currentState ='' ，下次进入仍然是显示cdwrapper

2：歌词单行过长的时候，我看css设置了不允许折行，感觉还是不太合理，在lyricwrapper 的p 元素 和 cdwarrper 的lyric_player 添加了white-space: normal;属性

由于我的vscode有prettier 这个插件，自动美化了作者的代码...介意的话我重新提个pr，不过我觉得这个插件很好用，安利一下～